### PR TITLE
feat: mqtt uplink proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Supported Features:
  * Device triggers & actions for automations
  * Various other service actions (e.g. request metrics, trace route)
  * Bundled meshtastic web client for manual interaction with gateway
+ * MQTT client proxy support (forwards messages from radio to MQTT broker)
 
 For more details, see check the [documentation](#documentation).
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ ruff==0.9.4
 
 bleak~=0.22.3
 pyserial-asyncio~=0.6
+
+aiomqtt>=1.2.0


### PR DESCRIPTION
This adds support for the MQTT client proxy feature. Currently only forwarding packets from the radio to the MQTT broker is supported (uplink).