### PR TITLE
refactor: migrate to paho-mqtt

### DIFF
--- a/custom_components/meshtastic/manifest.json
+++ b/custom_components/meshtastic/manifest.json
@@ -25,7 +25,7 @@
   "issue_tracker": "https://github.com/meshtastic/home-assistant/issues",
   "requirements": [
     "pyserial-asyncio==0.6",
-    "aiomqtt"
+    "paho-mqtt>=2.1.0"
   ],
   "usb": [
     {

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ ruff==0.11.2
 bleak~=0.22.3
 pyserial-asyncio~=0.6
 
-aiomqtt>=1.2.0
+paho-mqtt>=2.1.0


### PR DESCRIPTION
* The previous aiomqtt implementation was unreliable: when the MQTT broker closed the connection, the client often failed to auto-reconnect as expected.
* This change removes the aiomqtt wrapper and switches to using paho-mqtt directly.
* The new implementation has been running for two weeks with no issues.