### PR TITLE
feat: add reply_id to specify a message to reply to

### DIFF
--- a/custom_components/meshtastic/aiomeshtastic/connection/__init__.py
+++ b/custom_components/meshtastic/aiomeshtastic/connection/__init__.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2024-2025 Pascal Brogle @broglep
+# SPDX-FileCopyrightText: 2025 Ovidiu D. Nițan @ov1d1u
 #
 # SPDX-License-Identifier: MIT
 
@@ -250,6 +251,7 @@ class ClientApiConnection:
         *,
         from_node: int | None = None,
         ack: bool = False,
+        reply_id: int | None = None,
         want_response: bool = False,
         out_callback: Callable[[Packet], Awaitable[None]] | None = None,
         ack_callback: Callable[[Packet[mesh_pb2.Routing]], Awaitable[None]] | None = None,
@@ -263,6 +265,8 @@ class ClientApiConnection:
         )
         mesh_packet.decoded.portnum = port_num
         mesh_packet.decoded.want_response = want_response
+        if reply_id is not None:
+            mesh_packet.decoded.reply_id = reply_id
         mesh_packet.id = self._generate_packet_id()
         if from_node is not None:
             mesh_packet.__setattr__("from", from_node)

--- a/custom_components/meshtastic/aiomeshtastic/interface.py
+++ b/custom_components/meshtastic/aiomeshtastic/interface.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2024-2025 Pascal Brogle @broglep
 # SPDX-FileCopyrightText: 2025 Hendrik @novag
+# SPDX-FileCopyrightText: 2025 Ovidiu D. Nițan @ov1d1u
 #
 # SPDX-License-Identifier: MIT
 
@@ -1059,6 +1060,7 @@ class MeshInterface:
         want_ack: bool = False,
         channel_index: int | None = None,
         priority: MeshPacket.Priority | None = None,
+        reply_id: int | None = None,
         on_message_sent: Callable[[Packet], Awaitable[None]] | None = None,
     ) -> None:
         if isinstance(destination, MeshNode):
@@ -1106,6 +1108,7 @@ class MeshInterface:
             priority=priority or (MeshPacket.Priority.RELIABLE if want_ack else MeshPacket.Priority.DEFAULT),
             want_response=False,
             ack=want_ack,
+            reply_id=reply_id,
             out_callback=out_callback,
         )
 

--- a/custom_components/meshtastic/api.py
+++ b/custom_components/meshtastic/api.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2024-2025 Pascal Brogle @broglep
+# SPDX-FileCopyrightText: 2025 Ovidiu D. Nițan @ov1d1u
 #
 # SPDX-License-Identifier: MIT
 
@@ -245,6 +246,7 @@ class MeshtasticApiClient:
         *,
         want_ack: bool = False,
         channel_index: int | None = None,
+        reply_id: int | None = None,
     ) -> bool:
         async def _on_message_sent(packet: Packet) -> None:
             # publish event so that outgoing messages are recorded to logbook
@@ -259,6 +261,7 @@ class MeshtasticApiClient:
                     destination=destination_id,
                     want_ack=want_ack,
                     channel_index=channel_index,
+                    reply_id=reply_id,
                     on_message_sent=_on_message_sent,
                 ),
                 timeout=30,

--- a/custom_components/meshtastic/const.py
+++ b/custom_components/meshtastic/const.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2024-2025 Pascal Brogle @broglep
+# SPDX-FileCopyrightText: 2025 Ovidiu D. Nițan @ov1d1u
 #
 # SPDX-License-Identifier: MIT
 
@@ -65,6 +66,7 @@ ATTR_SERVICE_DATA_TO = "to"
 ATTR_SERVICE_DATA_CHANNEL = "channel"
 ATTR_SERVICE_DATA_FROM = "from"
 ATTR_SERVICE_DATA_ACK = "ack"
+ATTR_SERVICE_DATA_REPLY_ID = "reply_id"
 
 
 ATTR_SERVICE_SEND_TEXT_DATA_TEXT = "text"

--- a/custom_components/meshtastic/services.py
+++ b/custom_components/meshtastic/services.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2024-2025 Pascal Brogle @broglep
+# SPDX-FileCopyrightText: 2025 Ovidiu D. Nițan @ov1d1u
 #
 # SPDX-License-Identifier: MIT
 
@@ -36,6 +37,7 @@ from .const import (
     ATTR_SERVICE_DATA_ACK,
     ATTR_SERVICE_DATA_CHANNEL,
     ATTR_SERVICE_DATA_FROM,
+    ATTR_SERVICE_DATA_REPLY_ID,
     ATTR_SERVICE_DATA_TO,
     ATTR_SERVICE_REQUEST_TELEMETRY_DATA_TYPE,
     ATTR_SERVICE_SEND_DIRECT_MESSAGE_DATA_MESSAGE,
@@ -60,6 +62,7 @@ SERVICE_SEND_TEXT_SCHEMA = vol.Schema(
         vol.Optional(ATTR_SERVICE_DATA_FROM): cv.string,
         vol.Optional(ATTR_SERVICE_DATA_CHANNEL): cv.string,
         vol.Required(ATTR_SERVICE_DATA_ACK, default=False): cv.boolean,
+        vol.Optional(ATTR_SERVICE_DATA_REPLY_ID): cv.positive_int,
     }
 )
 
@@ -68,6 +71,7 @@ SERVICE_SEND_DIRECT_MESSAGE_SCHEMA = vol.Schema(
         vol.Required(ATTR_SERVICE_DATA_TO): cv.string,
         vol.Required(ATTR_SERVICE_SEND_DIRECT_MESSAGE_DATA_MESSAGE): cv.string,
         vol.Required(ATTR_SERVICE_DATA_ACK, default=True): cv.boolean,
+        vol.Optional(ATTR_SERVICE_DATA_REPLY_ID): cv.positive_int,
     }
 )
 
@@ -76,6 +80,7 @@ SERVICE_BROADCAST_CHANNEL_MESSAGE_SCHEMA = vol.Schema(
         vol.Required(ATTR_SERVICE_BROADCAST_CHANNEL_MESSAGE_DATA_CHANNEL): cv.string,
         vol.Required(ATTR_SERVICE_BROADCAST_CHANNEL_MESSAGE_DATA_MESSAGE): cv.string,
         vol.Required(ATTR_SERVICE_DATA_ACK, default=True): cv.boolean,
+        vol.Optional(ATTR_SERVICE_DATA_REPLY_ID): cv.positive_int,
     }
 )
 
@@ -283,7 +288,12 @@ async def _setup_service_send_direct_message_handler(
                 return _SERVICE_CANT_HANDLE_RESPONSE
 
         text = call.data[ATTR_SERVICE_SEND_DIRECT_MESSAGE_DATA_MESSAGE]
-        await client.send_text(text=text, destination_id=to_node_id, want_ack=call.data[ATTR_SERVICE_DATA_ACK])
+        await client.send_text(
+            text=text,
+            destination_id=to_node_id,
+            want_ack=call.data[ATTR_SERVICE_DATA_ACK],
+            reply_id=call.data.get(ATTR_SERVICE_DATA_REPLY_ID, None),
+        )
         return None
 
     _service_handlers[entry.entry_id][SERVICE_SEND_DIRECT_MESSAGE] = handle_service_call
@@ -314,7 +324,12 @@ async def _setup_service_broadcast_channel_message_handler(
         text = call.data[ATTR_SERVICE_BROADCAST_CHANNEL_MESSAGE_DATA_MESSAGE]
         channel_index = channel_entity.extra_state_attributes[STATE_ATTRIBUTE_CHANNEL_INDEX]
 
-        await client.send_text(text=text, channel_index=channel_index, want_ack=call.data[ATTR_SERVICE_DATA_ACK])
+        await client.send_text(
+            text=text,
+            channel_index=channel_index,
+            want_ack=call.data[ATTR_SERVICE_DATA_ACK],
+            reply_id=call.data.get(ATTR_SERVICE_DATA_REPLY_ID, None),
+        )
         return None
 
     _service_handlers[entry.entry_id][SERVICE_BROADCAST_CHANNEL_MESSAGE] = handle_service_call
@@ -357,6 +372,7 @@ async def _setup_service_send_text_handler(
             destination_id=to,
             channel_index=channel_index,
             want_ack=call.data[ATTR_SERVICE_DATA_ACK],
+            reply_id=call.data.get(ATTR_SERVICE_DATA_REPLY_ID, None),
         )
 
     _service_handlers[entry.entry_id][SERVICE_SEND_TEXT] = await _build_default_handler(hass, client, handler)

--- a/custom_components/meshtastic/services.yaml
+++ b/custom_components/meshtastic/services.yaml
@@ -34,7 +34,11 @@ send_text:
       required: true
       selector:
         boolean: {}
-
+    reply_id:
+      required: false
+      selector:
+        text:
+          multiline: false
 
 send_direct_message:
   fields:
@@ -53,6 +57,11 @@ send_direct_message:
       default: true
       selector:
         boolean: {}
+    reply_id:
+      required: false
+      selector:
+        text:
+          multiline: false
 
 broadcast_channel_message:
   fields:
@@ -73,7 +82,11 @@ broadcast_channel_message:
       default: true
       selector:
         boolean: {}
-
+    reply_id:
+      required: false
+      selector:
+        text:
+          multiline: false
 
 request_telemetry:
   fields:

--- a/custom_components/meshtastic/translations/en.json
+++ b/custom_components/meshtastic/translations/en.json
@@ -58,8 +58,7 @@
           "serial_port": "Path to serial port, e.g. /dev/ttyUSB0"
         }
       },
-      "reconfigure": {
-      },
+      "reconfigure": {},
       "node": {
         "description": "Configure which nodes should be imported",
         "data": {
@@ -177,6 +176,10 @@
         "ack": {
           "name": "Acknowledgement",
           "description": "Request an acknowledgement"
+        },
+        "reply_id": {
+          "name": "Reply ID",
+          "description": "A message ID to reply to."
         }
       }
     },
@@ -195,6 +198,10 @@
         "ack": {
           "name": "Acknowledgement",
           "description": "Request an acknowledgement"
+        },
+        "reply_id": {
+          "name": "Reply ID",
+          "description": "A message ID to reply to."
         }
       }
     },
@@ -213,6 +220,10 @@
         "ack": {
           "name": "Acknowledgement",
           "description": "Request an acknowledgement"
+        },
+        "reply_id": {
+          "name": "Reply ID",
+          "description": "A message ID to reply to."
         }
       }
     },


### PR DESCRIPTION
New Meshtastic apps have a feature that allows to reply to a specific message. This PR adds this feature to the Home Assistant integration, so you can specify such a `reply_id` for a message to reply to.