### PR TITLE
feat: add heap sensors

### DIFF
--- a/custom_components/meshtastic/sensor.py
+++ b/custom_components/meshtastic/sensor.py
@@ -479,6 +479,46 @@ def _build_local_stats_sensors(
             )
             for node_id, node_info in nodes_with_local_stats.items()
         ]
+
+        entities += [
+            MeshtasticSensor(
+                coordinator=coordinator,
+                entity_description=MeshtasticSensorEntityDescription(
+                    key="stats_heap_total_bytes",
+                    name="Heap Total",
+                    icon="mdi:memory",
+                    native_unit_of_measurement=UnitOfInformation.BYTES,
+                    device_class=SensorDeviceClass.DATA_SIZE,
+                    state_class=SensorStateClass.MEASUREMENT,
+                    value_fn=lambda device: device.coordinator.data[device.node_id]
+                    .get("localStats", {})
+                    .get("heapTotalBytes", None),
+                ),
+                gateway=gateway,
+                node_id=node_id,
+            )
+            for node_id, node_info in nodes_with_local_stats.items()
+        ]
+
+        entities += [
+            MeshtasticSensor(
+                coordinator=coordinator,
+                entity_description=MeshtasticSensorEntityDescription(
+                    key="stats_heap_free_bytes",
+                    name="Heap Free",
+                    icon="mdi:memory",
+                    native_unit_of_measurement=UnitOfInformation.BYTES,
+                    device_class=SensorDeviceClass.DATA_SIZE,
+                    state_class=SensorStateClass.MEASUREMENT,
+                    value_fn=lambda device: device.coordinator.data[device.node_id]
+                    .get("localStats", {})
+                    .get("heapFreeBytes", None),
+                ),
+                gateway=gateway,
+                node_id=node_id,
+            )
+            for node_id, node_info in nodes_with_local_stats.items()
+        ]
     except:  # noqa: E722
         LOGGER.warning("Failed to create local stats entities", exc_info=True)
 


### PR DESCRIPTION
I'm trying to see the behavior over time of the heap usage as I have some issues with my node so I thought it was a good idea to add it as a sensor in Home Assistant.

- Bump `protobuf` to version `2.6.9` (latest stable version) to support the `heap_{free,total}_bytes` fields in `LocalStats`.
- Add Heap Total and Heap Free Home Assistant sensors.

<img width="307" height="89" alt="image" src="https://github.com/user-attachments/assets/cef6504f-9326-4ab3-a32c-bd75d03a2e8b" />