### PR TITLE
Fix unique ID collision and via_device race conditionFix unique ID collision and via_device race condition

### DIFF
--- a/custom_components/meshtastic/__init__.py
+++ b/custom_components/meshtastic/__init__.py
@@ -229,6 +229,7 @@ async def _setup_meshtastic_device(  # noqa: PLR0913
     gateway_node: Mapping[str, Any],
     node: Mapping[str, Any],
     node_id: int,
+    *,
     ignore_via_device: bool = False,
 ) -> None:
     gateway_node_id = cast("int", gateway_node["num"])
@@ -266,11 +267,7 @@ async def _setup_meshtastic_device(  # noqa: PLR0913
         via_device = (DOMAIN, str(gateway_node_id)) if gateway_node_id != node_id else None
 
     # remove via_device when it is set to ourself
-    if (
-        (via_device is not None and int(via_device[1]) == node_id)
-        or (gateway_node_id == node_id)
-        or ignore_via_device
-    ):
+    if (via_device is not None and int(via_device[1]) == node_id) or (gateway_node_id == node_id) or ignore_via_device:
         via_device = None
 
     if existing_device:

--- a/custom_components/meshtastic/__init__.py
+++ b/custom_components/meshtastic/__init__.py
@@ -187,11 +187,25 @@ async def _setup_meshtastic_devices(
     for node_id, node in nodes.items():
         if node_id in filter_node_nums:
             await _setup_meshtastic_device(
-                client, device_hardware_names, device_registry, entry, gateway_node, node, node_id
+                client,
+                device_hardware_names,
+                device_registry,
+                entry,
+                gateway_node,
+                node,
+                node_id,
+                ignore_via_device=True,
             )
 
         else:
             await _remove_meshtastic_device(device_registry, entry, node_id)
+
+    for node_id, node in nodes.items():
+        if node_id in filter_node_nums:
+            await _setup_meshtastic_device(
+                client, device_hardware_names, device_registry, entry, gateway_node, node, node_id
+            )
+
     return gateway_node
 
 
@@ -215,6 +229,7 @@ async def _setup_meshtastic_device(  # noqa: PLR0913
     gateway_node: Mapping[str, Any],
     node: Mapping[str, Any],
     node_id: int,
+    ignore_via_device: bool = False,
 ) -> None:
     gateway_node_id = cast("int", gateway_node["num"])
     mac_address = base64.b64decode(node["user"]["macaddr"]).hex(":") if "macaddr" in node["user"] else None
@@ -251,7 +266,11 @@ async def _setup_meshtastic_device(  # noqa: PLR0913
         via_device = (DOMAIN, str(gateway_node_id)) if gateway_node_id != node_id else None
 
     # remove via_device when it is set to ourself
-    if (via_device is not None and int(via_device[1]) == node_id) or (gateway_node_id == node_id):
+    if (
+        (via_device is not None and int(via_device[1]) == node_id)
+        or (gateway_node_id == node_id)
+        or ignore_via_device
+    ):
         via_device = None
 
     if existing_device:

--- a/custom_components/meshtastic/helpers.py
+++ b/custom_components/meshtastic/helpers.py
@@ -50,7 +50,8 @@ async def setup_platform_entry(
 
     def on_coordinator_data_update() -> None:
         entities = entity_factory(get_nodes(entry), entry.runtime_data)
-        new_entities = [s for s in entities if s.entity_id not in platform.entities]
+        existing_unique_ids = {e.unique_id for e in platform.entities.values()}
+        new_entities = [s for s in entities if s.unique_id not in existing_unique_ids]
         if new_entities:
             async_add_entities(new_entities)
 


### PR DESCRIPTION
Fixes #114 and #61

## Changes
- **Unique ID Collision**: Modified `helpers.py` to check against `unique_id` instead of `entity_id` when filtering new entities.
- **Via Device Error**: Modified `__init__.py` to use a two-pass approach for device setup, ensuring all devices exist before linking them with `via_device`.