### PR TITLE
Extend meshtastic_api_text_message for additional data

### DIFF
--- a/custom_components/meshtastic/aiomeshtastic/packet.py
+++ b/custom_components/meshtastic/aiomeshtastic/packet.py
@@ -46,6 +46,10 @@ class Packet[T]:
     @property
     def port_num(self) -> portnums_pb2.PortNum | None:
         return self.data.portnum if self.data is not None else None
+    
+    @property
+    def hops_count(self) -> int:
+        return self.mesh_packet.hop_start - self.mesh_packet.hop_limit
 
     @cached_property
     def app_payload(self) -> T:  # noqa: PLR0911

--- a/custom_components/meshtastic/api.py
+++ b/custom_components/meshtastic/api.py
@@ -277,6 +277,9 @@ class MeshtasticApiClient:
                 "to": {"node": to_node, "channel": to_channel},
                 "gateway": self.get_own_node()["num"],
                 "message": packet.app_payload,
+                "hops_count": packet.hops_count,
+                "rx_rssi": packet.mesh_packet.rx_rssi,
+                "rx_snr": packet.mesh_packet.rx_snr,
             },
         )
 


### PR DESCRIPTION
Added to meshtastic_api_text_message fields `hops_count`, `rx_rssi` and `rx_snr`.
Using me in automatization auto replay for direct message

Example:

```yaml
alias: Echo on Direct Message
description: Only from gateway with node id __masked__
triggers:
  - trigger: event
    event_type: meshtastic_api_text_message
    event_data:
      data:
        to:
          node: __masked__
          channel: null
        gateway: __masked__
conditions: []
actions:
  - delay:
      seconds: 1
  - action: meshtastic.send_text
    data:
      ack: true
      text: >-
        Hops: {{ trigger.event.data.data.hops_count }},  
        rssi: {{ trigger.event.data.data.rx_rssi }}dBm,  
        snr: {{ trigger.event.data.data.rx_snr }}dB. 

        ECHO: {{ trigger.event.data.data.message }}
      from: "{{ trigger.event.data.data.gateway }}"
      to: "{{ trigger.event.data.data.from }}"
mode: single
```