### PR TITLE
fix: add details that MAC addr letters needs to be capitalized

### DIFF
--- a/custom_components/meshtastic/translations/en.json
+++ b/custom_components/meshtastic/translations/en.json
@@ -31,7 +31,7 @@
           "bluetooth_address": "Bluetooth Address"
         },
         "data_description": {
-          "bluetooth_address": "Device address in form of 00:11:22:33:FF:EE"
+          "bluetooth_address": "Device address in form of 00:11:22:33:FF:EE. Letters must be capitalized."
         }
       },
       "discovery_bluetooth_confirm": {


### PR DESCRIPTION
Updated the description for bluetooth_address to specify that letters must be capitalized.