### PR TITLE
feat: expose online node names on Online Nodes sensor

### DIFF
--- a/custom_components/meshtastic/api.py
+++ b/custom_components/meshtastic/api.py
@@ -197,6 +197,10 @@ class MeshtasticApiClient:
     def get_node_info(self, node_id: int) -> MeshNode | None:
         return self._interface.find_node(node_id=node_id)
 
+    def get_all_nodes_raw(self) -> Mapping[int, Mapping[str, Any]]:
+        """Return the full unfiltered node database from the mesh interface."""
+        return self._interface.nodes()
+
     async def async_get_all_nodes(self) -> Mapping[int, Mapping[str, Any]]:
         await self._interface.connected_node_ready()
         return {node_id: self._transform_node_info(node_info) for node_id, node_info in self._interface.nodes().items()}

--- a/custom_components/meshtastic/sensor.py
+++ b/custom_components/meshtastic/sensor.py
@@ -80,6 +80,7 @@ async def async_unload_entry(
 class MeshtasticSensorEntityDescription(SensorEntityDescription):
     exists_fn: Callable[[MeshtasticSensor], bool] = lambda _: True
     value_fn: Callable[[MeshtasticSensor], StateType]
+    attr_fn: Callable[[MeshtasticSensor], dict[str, Any] | None] = lambda _: None
 
 
 class MeshtasticSensor(MeshtasticNodeEntity, SensorEntity):
@@ -99,6 +100,9 @@ class MeshtasticSensor(MeshtasticNodeEntity, SensorEntity):
         LOGGER.debug("Updating sensor attributes: %s", self)
         self._attr_native_value = self.entity_description.value_fn(self)
         self._attr_available = self._attr_native_value is not None
+        extra_attrs = self.entity_description.attr_fn(self)
+        if extra_attrs is not None:
+            self._attr_extra_state_attributes = extra_attrs
 
 
 def _build_node_sensors(
@@ -325,6 +329,31 @@ def _build_device_sensors(
     return entities
 
 
+_ONLINE_THRESHOLD_SECONDS = 2 * 60 * 60  # 2 hours, matches Meshtastic firmware default
+
+
+def _online_nodes_attributes(device: MeshtasticSensor) -> dict[str, Any]:
+    now = datetime.datetime.now(tz=datetime.UTC).timestamp()
+    online_nodes: list[str] = []
+    try:
+        all_nodes = device.coordinator.config_entry.runtime_data.client.get_all_nodes_raw()
+    except Exception:
+        all_nodes = device.coordinator.data
+    for node_id, node_data in all_nodes.items():
+        last_heard = node_data.get("lastHeard")
+        if last_heard is None:
+            continue
+        if (now - last_heard) > _ONLINE_THRESHOLD_SECONDS:
+            continue
+        long_name = node_data.get("user", {}).get("longName")
+        short_name = node_data.get("user", {}).get("shortName")
+        name = long_name or short_name or f"!{node_id:08x}"
+        last_heard_dt = datetime.datetime.fromtimestamp(last_heard, tz=datetime.UTC)
+        online_nodes.append(f"{name} (last heard: {last_heard_dt.strftime('%Y-%m-%d %H:%M:%S UTC')})")
+    online_nodes.sort()
+    return {"online_nodes": online_nodes}
+
+
 def _build_local_stats_sensors(
     nodes: Mapping[int, Mapping[str, Any]], runtime_data: MeshtasticData
 ) -> Iterable[MeshtasticSensor]:
@@ -453,6 +482,7 @@ def _build_local_stats_sensors(
                     value_fn=lambda device: device.coordinator.data[device.node_id]
                     .get("localStats", {})
                     .get("numOnlineNodes", None),
+                    attr_fn=_online_nodes_attributes,
                 ),
                 gateway=gateway,
                 node_id=node_id,


### PR DESCRIPTION
## Summary

- Adds an `online_nodes` extra state attribute to the **Online Nodes** sensor, listing all mesh nodes heard within the last 2 hours (matching the Meshtastic firmware default threshold)
- Each entry includes the node's long name (falling back to short name or hex ID) and last heard UTC timestamp
- Uses the full unfiltered node database from the mesh interface via a new `get_all_nodes_raw()` public method on `MeshtasticApiClient`, so all nodes are listed regardless of the config entry node filter
- Adds a generic `attr_fn` field to `MeshtasticSensorEntityDescription`, allowing any sensor to expose extra state attributes in the future

## Motivation

Multiple users have requested the ability to see which nodes are online by name, rather than just a count. This exposes the data as a sensor attribute, making it accessible to Lovelace cards, templates, and automations.

## Test plan

- [ ] Verify the Online Nodes sensor state still reports the firmware-provided count
- [ ] Verify the `online_nodes` attribute appears in Developer Tools > States
- [ ] Verify the attribute lists nodes heard within the last 2 hours with correct names and timestamps
- [ ] Verify nodes not heard within 2 hours are excluded
- [ ] Verify other sensors are unaffected (attr_fn defaults to None)