### PR TITLE
fix: pass BLEDevice to BleakClient for Bluetooth proxy support

### DIFF
--- a/custom_components/meshtastic/aiomeshtastic/connection/bluetooth.py
+++ b/custom_components/meshtastic/aiomeshtastic/connection/bluetooth.py
@@ -41,10 +41,15 @@ class BluetoothConnection(ClientApiConnection):
     BTM_CHARACTERISTIC_LOG_UUID = "5a3d6e49-06e6-4423-9944-e9de8cdf9547"
 
     def __init__(
-        self, ble_address: str, bleak_client_backend: type[BaseBleakClient] | None = None, connect_timeout: float = 10.0
+        self,
+        ble_address: str,
+        ble_device: Any | None = None,
+        bleak_client_backend: type[BaseBleakClient] | None = None,
+        connect_timeout: float = 10.0,
     ) -> None:
         super().__init__()
         self._ble_address = ble_address
+        self._ble_device = ble_device
         self._bleak_client_backend = bleak_client_backend
         self._connect_timeout = connect_timeout
         self._ble_meshtastic_service: BleakGATTService | None = None
@@ -57,8 +62,9 @@ class BluetoothConnection(ClientApiConnection):
         self._force_read_event = asyncio.Event()
 
     async def _connect(self) -> None:
+        target = self._ble_device if self._ble_device is not None else self._ble_address
         self._bleak_client = BleakClient(
-            self._ble_address, timeout=self._connect_timeout, backend=self._bleak_client_backend
+            target, timeout=self._connect_timeout, backend=self._bleak_client_backend
         )
         await self._bleak_client.connect()
 

--- a/custom_components/meshtastic/aiomeshtastic/connection/bluetooth.py
+++ b/custom_components/meshtastic/aiomeshtastic/connection/bluetooth.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 import bleak
 from bleak import BaseBleakClient, BleakClient, BleakGATTCharacteristic
+from bleak_retry_connector import establish_connection
 from google.protobuf import message
 
 from ..protobuf import mesh_pb2  # noqa: TID252
@@ -62,9 +63,18 @@ class BluetoothConnection(ClientApiConnection):
         self._force_read_event = asyncio.Event()
 
     async def _connect(self) -> None:
-        target = self._ble_device if self._ble_device is not None else self._ble_address
-        self._bleak_client = BleakClient(target, timeout=self._connect_timeout, backend=self._bleak_client_backend)
-        await self._bleak_client.connect()
+        if self._ble_device is not None:
+            self._bleak_client = await establish_connection(
+                client_class=BleakClient,
+                device=self._ble_device,
+                name=self._ble_address,
+                max_attempts=3,
+            )
+        else:
+            self._bleak_client = BleakClient(
+                self._ble_address, timeout=self._connect_timeout, backend=self._bleak_client_backend
+            )
+            await self._bleak_client.connect()
 
         # attempt pairing, we don't know if it is required. Should not harm if
         # not needed. if pairing is required, external input is necessary as we are not

--- a/custom_components/meshtastic/aiomeshtastic/connection/bluetooth.py
+++ b/custom_components/meshtastic/aiomeshtastic/connection/bluetooth.py
@@ -63,9 +63,7 @@ class BluetoothConnection(ClientApiConnection):
 
     async def _connect(self) -> None:
         target = self._ble_device if self._ble_device is not None else self._ble_address
-        self._bleak_client = BleakClient(
-            target, timeout=self._connect_timeout, backend=self._bleak_client_backend
-        )
+        self._bleak_client = BleakClient(target, timeout=self._connect_timeout, backend=self._bleak_client_backend)
         await self._bleak_client.connect()
 
         # attempt pairing, we don't know if it is required. Should not harm if

--- a/custom_components/meshtastic/api.py
+++ b/custom_components/meshtastic/api.py
@@ -106,7 +106,13 @@ class MeshtasticApiClient:
         if connection_type == ConnectionType.TCP.value:
             connection = AioTcpConnection(host=data[CONF_CONNECTION_TCP_HOST], port=data[CONF_CONNECTION_TCP_PORT])
         elif connection_type == ConnectionType.BLUETOOTH.value:
-            connection = AioBluetoothConnection(ble_address=data[CONF_CONNECTION_BLUETOOTH_ADDRESS])
+            ble_address = data[CONF_CONNECTION_BLUETOOTH_ADDRESS]
+            ble_device = None
+            if hass:
+                from homeassistant.components.bluetooth import async_ble_device_from_address
+
+                ble_device = async_ble_device_from_address(hass, ble_address, connectable=True)
+            connection = AioBluetoothConnection(ble_address=ble_address, ble_device=ble_device)
         elif connection_type == ConnectionType.SERIAL.value:
             connection = AioSerialConnection(device=data[CONF_CONNECTION_SERIAL_PORT])
         else:


### PR DESCRIPTION
## Problem

When connecting to a Meshtastic device via Bluetooth, the integration passes a raw address string to `BleakClient`. This causes two issues:

1. `habluetooth` cannot determine which proxy backend can route the connection, resulting in:
   ```
   BleakError: No backend with an available connection slot that can reach address XX:XX:XX:XX:XX:XX was found
   ```

2. `habluetooth` logs a warning on every connection:
   ```
   BleakClient.connect() called without bleak-retry-connector. For reliable connection
   establishment, use bleak_retry_connector.establish_connection().
   ```

## Fix

- Look up the `BLEDevice` via `async_ble_device_from_address()` before creating the `BluetoothConnection`
- Pass the `BLEDevice` through to `BluetoothConnection` so `habluetooth` can route through the correct proxy
- Use `establish_connection()` from `bleak-retry-connector` when a `BLEDevice` is available, which handles connection slot management and automatic retries
- Falls back to direct `BleakClient.connect()` with the raw address string when no `BLEDevice` is available

## Testing

Tested with a Meshtastic device connected via Bluetooth and via an ESPHome Bluetooth proxy. Both the `BleakError` and the `habluetooth` warning no longer appear after this fix.