### PR TITLE
fix: use port 8883 as default for MQTT when TLS is enabled

### DIFF
--- a/custom_components/meshtastic/aiomeshtastic/interface.py
+++ b/custom_components/meshtastic/aiomeshtastic/interface.py
@@ -418,7 +418,8 @@ class MeshInterface:
 
         # Parse broker address
         hostname = broker.split(":", 1)[0]
-        port = int(broker.split(":", 1)[1]) if ":" in broker else 1883
+        default_port = 8883 if use_tls else 1883
+        port = int(broker.split(":", 1)[1]) if ":" in broker else default_port
 
         # Get node ID for client identifier
         node_id = self._connected_node_info.my_node_num


### PR DESCRIPTION
## Problem

When the MQTT broker address on the Meshtastic device doesn't include an explicit port (e.g. `mqtt.example.com` instead of `mqtt.example.com:8883`), the MQTT proxy always defaults to port 1883 — even when `tls_enabled` is true.

This causes the connection to fail with `[Errno 104] Connection reset by peer` because the broker expects a TLS handshake on port 8883, not a plaintext connection on 1883. The proxy then retries every 5 seconds, filling the logs with connection errors.

## Fix

Default to port 8883 when `tls_enabled` is true, 1883 when it's false. An explicit port in the broker address still takes priority.

## Testing

Tested with a custom MQTT broker using TLS. Before this fix, the MQTT proxy logs `Connection reset by peer` every 5 seconds. After this fix, the proxy connects successfully on port 8883.