### PR TITLE
Fix air quality telemetry propagation and sensor labels

### DIFF
--- a/custom_components/meshtastic/api.py
+++ b/custom_components/meshtastic/api.py
@@ -74,6 +74,7 @@ class EventMeshtasticApiTelemetryType(StrEnum):
     DEVICE_METRICS = "device_metrics"
     LOCAL_STATS = "local_stats"
     ENVIRONMENT_METRICS = "environment_metrics"
+    AIR_QUALITY_METRICS = "air_quality_metrics"
     POWER_METRICS = "power_metrics"
 
 
@@ -287,6 +288,7 @@ class MeshtasticApiClient:
         device_metrics = telemetry.get("deviceMetrics")
         local_stats = telemetry.get("localStats")
         environment_metrics = telemetry.get("environmentMetrics")
+        air_quality_metrics = telemetry.get("airQualityMetrics")
         power_metrics = telemetry.get("powerMetrics")
 
         node_info = {"name": node.long_name}
@@ -306,6 +308,12 @@ class MeshtasticApiClient:
             event_data = self._build_event_data(node.id, environment_metrics)
             event_data[ATTR_EVENT_MESHTASTIC_API_NODE_INFO] = node_info
             event_data[ATTR_EVENT_MESHTASTIC_API_TELEMETRY_TYPE] = EventMeshtasticApiTelemetryType.ENVIRONMENT_METRICS
+            self._hass.bus.async_fire(EVENT_MESHTASTIC_API_TELEMETRY, event_data)
+
+        if air_quality_metrics:
+            event_data = self._build_event_data(node.id, air_quality_metrics)
+            event_data[ATTR_EVENT_MESHTASTIC_API_NODE_INFO] = node_info
+            event_data[ATTR_EVENT_MESHTASTIC_API_TELEMETRY_TYPE] = EventMeshtasticApiTelemetryType.AIR_QUALITY_METRICS
             self._hass.bus.async_fire(EVENT_MESHTASTIC_API_TELEMETRY, event_data)
 
         if power_metrics:

--- a/custom_components/meshtastic/coordinator.py
+++ b/custom_components/meshtastic/coordinator.py
@@ -124,6 +124,8 @@ class MeshtasticDataUpdateCoordinator(DataUpdateCoordinator):
             metric_type = "powerMetrics"
         elif telemetry_type == EventMeshtasticApiTelemetryType.ENVIRONMENT_METRICS:
             metric_type = "environmentMetrics"
+        elif telemetry_type == EventMeshtasticApiTelemetryType.AIR_QUALITY_METRICS:
+            metric_type = "airQualityMetrics"
         else:
             self._logger.warning("Unsupported telemetry type %s", telemetry_type)
             return

--- a/custom_components/meshtastic/sensor.py
+++ b/custom_components/meshtastic/sensor.py
@@ -50,6 +50,10 @@ if TYPE_CHECKING:
     from .data import MeshtasticConfigEntry, MeshtasticData
 
 
+UNIT_PARTICLES_PER_DECILITER = "particles/dL"
+UNIT_MEGAOHM = "MOhm"
+
+
 def _build_sensors(nodes: Mapping[int, Mapping[str, Any]], runtime_data: MeshtasticData) -> Iterable[MeshtasticSensor]:
     entities = []
     entities += _build_node_sensors(nodes, runtime_data)
@@ -565,6 +569,7 @@ def _build_environment_metrics_sensors(
     def add_sensor_base(  # noqa: PLR0913
         node_id: int,
         node_info: dict[str, Any],
+        name: str,
         value_key: str,
         device_class: SensorDeviceClass | None,
         unit_of_measurement: str | None = None,
@@ -577,6 +582,7 @@ def _build_environment_metrics_sensors(
                     coordinator=coordinator,
                     entity_description=MeshtasticSensorEntityDescription(
                         key="environment_" + key,
+                        name=name,
                         translation_key="environment_" + key,
                         native_unit_of_measurement=unit_of_measurement,
                         device_class=device_class,
@@ -592,25 +598,30 @@ def _build_environment_metrics_sensors(
         for node_id, node_info in nodes_with_environment_metrics.items():
             add_sensor = partial(add_sensor_base, node_id, node_info)
 
-            add_sensor("temperature", SensorDeviceClass.TEMPERATURE, UnitOfTemperature.CELSIUS)
-            add_sensor("relativeHumidity", SensorDeviceClass.HUMIDITY, PERCENTAGE)
-            add_sensor("barometricPressure", SensorDeviceClass.ATMOSPHERIC_PRESSURE, UnitOfPressure.HPA)
-            add_sensor("gasResistance", None, UnitOfPressure.HPA)
-            add_sensor("iaq", SensorDeviceClass.AQI, None)
+            add_sensor("Temperature", "temperature", SensorDeviceClass.TEMPERATURE, UnitOfTemperature.CELSIUS)
+            add_sensor("Relative Humidity", "relativeHumidity", SensorDeviceClass.HUMIDITY, PERCENTAGE)
+            add_sensor(
+                "Barometric Pressure",
+                "barometricPressure",
+                SensorDeviceClass.ATMOSPHERIC_PRESSURE,
+                UnitOfPressure.HPA,
+            )
+            add_sensor("Gas Resistance", "gasResistance", None, UNIT_MEGAOHM)
+            add_sensor("Indoor Air Quality", "iaq", SensorDeviceClass.AQI, None)
 
-            add_sensor("distance", SensorDeviceClass.DISTANCE, UnitOfLength.MILLIMETERS)
+            add_sensor("Distance", "distance", SensorDeviceClass.DISTANCE, UnitOfLength.MILLIMETERS)
 
-            add_sensor("lux", SensorDeviceClass.ILLUMINANCE, LIGHT_LUX)
-            add_sensor("white_lux", SensorDeviceClass.ILLUMINANCE, LIGHT_LUX)
-            add_sensor("ir_lux", SensorDeviceClass.ILLUMINANCE, LIGHT_LUX)
-            add_sensor("uv_lux", SensorDeviceClass.ILLUMINANCE, LIGHT_LUX)
+            add_sensor("Illuminance", "lux", SensorDeviceClass.ILLUMINANCE, LIGHT_LUX)
+            add_sensor("White Light", "white_lux", SensorDeviceClass.ILLUMINANCE, LIGHT_LUX)
+            add_sensor("Infrared Light", "ir_lux", SensorDeviceClass.ILLUMINANCE, LIGHT_LUX)
+            add_sensor("Ultraviolet Light", "uv_lux", SensorDeviceClass.ILLUMINANCE, LIGHT_LUX)
 
-            add_sensor("wind_direction", SensorDeviceClass.WIND_SPEED, DEGREE)
-            add_sensor("wind_speed", SensorDeviceClass.WIND_SPEED, UnitOfSpeed.METERS_PER_SECOND)
-            add_sensor("wind_gust", SensorDeviceClass.WIND_SPEED, UnitOfSpeed.METERS_PER_SECOND)
-            add_sensor("wind_lull", SensorDeviceClass.WIND_SPEED, UnitOfSpeed.METERS_PER_SECOND)
+            add_sensor("Wind Direction", "wind_direction", None, DEGREE)
+            add_sensor("Wind Speed", "wind_speed", SensorDeviceClass.WIND_SPEED, UnitOfSpeed.METERS_PER_SECOND)
+            add_sensor("Wind Gust", "wind_gust", None, UnitOfSpeed.METERS_PER_SECOND)
+            add_sensor("Wind Lull", "wind_lull", None, UnitOfSpeed.METERS_PER_SECOND)
 
-            add_sensor("weight", SensorDeviceClass.WEIGHT, UnitOfMass.KILOGRAMS)
+            add_sensor("Weight", "weight", SensorDeviceClass.WEIGHT, UnitOfMass.KILOGRAMS)
 
     except:  # noqa: E722
         LOGGER.warning("Failed to create environment metric entities", exc_info=True)
@@ -637,6 +648,7 @@ def _build_air_quality_metrics_sensors(
     def add_sensor_base(  # noqa: PLR0913
         node_id: int,
         node_info: dict[str, Any],
+        name: str,
         value_key: str,
         device_class: SensorDeviceClass | None,
         unit_of_measurement: str | None = None,
@@ -649,6 +661,7 @@ def _build_air_quality_metrics_sensors(
                     coordinator=coordinator,
                     entity_description=MeshtasticSensorEntityDescription(
                         key="airquality_" + key,
+                        name=name,
                         translation_key="airquality_" + key,
                         native_unit_of_measurement=unit_of_measurement,
                         device_class=device_class,
@@ -664,20 +677,35 @@ def _build_air_quality_metrics_sensors(
         for node_id, node_info in nodes_with_environment_metrics.items():
             add_sensor = partial(add_sensor_base, node_id, node_info)
 
-            add_sensor("pm10Standard", SensorDeviceClass.PM10, CONCENTRATION_MICROGRAMS_PER_CUBIC_METER)
-            add_sensor("pm25Standard", SensorDeviceClass.PM25, CONCENTRATION_MICROGRAMS_PER_CUBIC_METER)
-            add_sensor("pm100Standard", None, CONCENTRATION_MICROGRAMS_PER_CUBIC_METER)
+            add_sensor("PM1.0 Standard", "pm10Standard", None, CONCENTRATION_MICROGRAMS_PER_CUBIC_METER)
+            add_sensor(
+                "PM2.5 Standard",
+                "pm25Standard",
+                SensorDeviceClass.PM25,
+                CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+            )
+            add_sensor("PM10 Standard", "pm100Standard", SensorDeviceClass.PM10, CONCENTRATION_MICROGRAMS_PER_CUBIC_METER)
 
-            add_sensor("pm10Environmental", SensorDeviceClass.PM10, CONCENTRATION_MICROGRAMS_PER_CUBIC_METER)
-            add_sensor("pm25Environmental", SensorDeviceClass.PM25, CONCENTRATION_MICROGRAMS_PER_CUBIC_METER)
-            add_sensor("pm100Environmental", None, CONCENTRATION_MICROGRAMS_PER_CUBIC_METER)
+            add_sensor("PM1.0 Environmental", "pm10Environmental", None, CONCENTRATION_MICROGRAMS_PER_CUBIC_METER)
+            add_sensor(
+                "PM2.5 Environmental",
+                "pm25Environmental",
+                SensorDeviceClass.PM25,
+                CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+            )
+            add_sensor(
+                "PM10 Environmental",
+                "pm100Environmental",
+                SensorDeviceClass.PM10,
+                CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+            )
 
-            add_sensor("particles03um", None, CONCENTRATION_MICROGRAMS_PER_CUBIC_METER)
-            add_sensor("particles05um", None, CONCENTRATION_MICROGRAMS_PER_CUBIC_METER)
-            add_sensor("particles10um", SensorDeviceClass.PM10, CONCENTRATION_MICROGRAMS_PER_CUBIC_METER)
-            add_sensor("particles25um", SensorDeviceClass.PM25, CONCENTRATION_MICROGRAMS_PER_CUBIC_METER)
-            add_sensor("particles50um", None, CONCENTRATION_MICROGRAMS_PER_CUBIC_METER)
-            add_sensor("particles100um", None, CONCENTRATION_MICROGRAMS_PER_CUBIC_METER)
+            add_sensor("Particles 0.3um", "particles03um", None, UNIT_PARTICLES_PER_DECILITER)
+            add_sensor("Particles 0.5um", "particles05um", None, UNIT_PARTICLES_PER_DECILITER)
+            add_sensor("Particles 1.0um", "particles10um", None, UNIT_PARTICLES_PER_DECILITER)
+            add_sensor("Particles 2.5um", "particles25um", None, UNIT_PARTICLES_PER_DECILITER)
+            add_sensor("Particles 5.0um", "particles50um", None, UNIT_PARTICLES_PER_DECILITER)
+            add_sensor("Particles 10.0um", "particles100um", None, UNIT_PARTICLES_PER_DECILITER)
     except:  # noqa: E722
         LOGGER.warning("Failed to create air quality metric entities", exc_info=True)
 


### PR DESCRIPTION
## Summary

This fixes two related issues around Meshtastic air quality metrics in Home Assistant:

1. `air_quality_metrics` packets were decoded by the integration, but never forwarded through the API/coordinator event pipeline, so the coordinator never stored them under `airQualityMetrics`.
2. Once air quality entities were created, several of them appeared in HA with generic or misleading names because the entity descriptions did not define explicit names, and a few metrics also had incorrect labels/units.

## Problem

I reproduced this with a node returning valid `airQualityMetrics` over the HA TCP proxy. Direct requests and proxy requests both returned correct payloads, but Home Assistant did not surface the air quality values correctly.

Observed behavior before this patch:
- `air_quality_metrics` responses were received, but HA did not update coordinator state for them.
- Some air quality entities appeared as the device name instead of metric names.
- `pm10Standard` / `pm10Environmental` were presented like PM10 even though Meshtastic maps those fields to PM1.0.
- `gasResistance` was exposed as `hPa` even though the protobuf describes it as `MOhm`.
- `particles*` counters were exposed as `μg/m³`, even though they are particle counts, not mass concentration.

## Root cause

`MeshtasticApiClient._on_telemetry()` handled:
- `deviceMetrics`
- `localStats`
- `environmentMetrics`
- `powerMetrics`

but not `airQualityMetrics`.

`MeshtasticDataUpdateCoordinator._api_telemetry()` also did not recognize an `air_quality_metrics` event type, so even if the event existed it would have been dropped as unsupported.

Separately, the air quality/environment sensor builders relied on `translation_key` only. For metrics without a Home Assistant-generated friendly fallback, HA ended up displaying the device name or overly generic names instead of the specific metric.

## Changes

- Add `AIR_QUALITY_METRICS` to `EventMeshtasticApiTelemetryType`
- Forward `telemetry["airQualityMetrics"]` as `EVENT_MESHTASTIC_API_TELEMETRY`
- Map that event in the coordinator to `airQualityMetrics`
- Add explicit names for environment and air quality sensor entities
- Correct metric naming for Meshtastic PM buckets:
  - `pm10*` -> `PM1.0 *`
  - `pm25*` -> `PM2.5 *`
  - `pm100*` -> `PM10 *`
- Correct `gasResistance` unit from `hPa` to `MOhm`
- Expose `particles*` values as `particles/dL` instead of `μg/m³`

## Testing

Local verification performed:
- `python -m py_compile custom_components/meshtastic/api.py custom_components/meshtastic/coordinator.py custom_components/meshtastic/sensor.py`
- `git diff --check -- custom_components/meshtastic/api.py custom_components/meshtastic/coordinator.py custom_components/meshtastic/sensor.py`
- Live telemetry request against the user's HA TCP proxy and target node, confirming payload contents:

```text
Telemetry received:
airQualityMetrics:
  pm10Standard: 9
  pm25Standard: 15
  pm100Standard: 20
  pm10Environmental: 9
  pm25Environmental: 15
  pm100Environmental: 20
  particles03um: 605
  particles05um: 534
  particles10um: 54
  particles25um: 0
  particles50um: 0
  particles100um: 0
```

I could not run `scripts/lint` in this environment because `ruff` is not installed locally, but the patch was kept small and `py_compile` / `git diff --check` passed.

## Notes

- No documentation changes are needed for this bug fix.
- This patch intentionally stays limited to the existing telemetry/sensor plumbing and sensor metadata.
