### PR TITLE
Replace deprecated pyserial-asyncio dependency

### DIFF
--- a/custom_components/meshtastic/aiomeshtastic/connection/serial.py
+++ b/custom_components/meshtastic/aiomeshtastic/connection/serial.py
@@ -9,7 +9,7 @@ from asyncio import StreamReader, StreamReaderProtocol, StreamWriter
 from typing import cast
 
 import serial
-import serial_asyncio
+import serial_asyncio_fast as serial_asyncio
 
 from custom_components.meshtastic.aiomeshtastic.connection import (
     ClientApiConnectionError,

--- a/custom_components/meshtastic/manifest.json
+++ b/custom_components/meshtastic/manifest.json
@@ -24,7 +24,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/meshtastic/home-assistant/issues",
   "requirements": [
-    "pyserial-asyncio==0.6",
+    "pyserial-asyncio-fast==0.16",
     "aiomqtt"
   ],
   "usb": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ pip>=21.3.1
 ruff==0.11.8
 
 bleak~=0.22.3
-pyserial-asyncio~=0.6
+pyserial-asyncio-fast~=0.16
 
 aiomqtt>=1.2.0


### PR DESCRIPTION
## Summary
- replace the integration requirement from `pyserial-asyncio` to `pyserial-asyncio-fast`
- update the development requirements file to use the same replacement package
- update the serial transport import to use `serial_asyncio_fast` explicitly

## Why
Home Assistant Core now warns that `pyserial-asyncio` is deprecated for integrations and should be replaced by `pyserial-asyncio-fast`; the warning says the old package will stop working in Home Assistant 2026.7.

The code change is needed because `pyserial-asyncio-fast` exposes the replacement module as `serial_asyncio_fast`, not `serial_asyncio`. Without this import update, the integration's serial backend would no longer load when only the replacement package is installed.

## Testing
- `python -m ruff check .`
- `python -m ruff format . --check`
- `git diff --check`
- isolated Python smoke: verified `pyserial-asyncio-fast==0.16` is installed, `pyserial-asyncio` is not installed, and `custom_components.meshtastic.aiomeshtastic.connection.serial.SerialConnection` imports with `serial_asyncio_fast`
