### PR TITLE
Use modern serialx instead of pyserial-asyncio

### DIFF
--- a/custom_components/meshtastic/aiomeshtastic/connection/serial.py
+++ b/custom_components/meshtastic/aiomeshtastic/connection/serial.py
@@ -6,8 +6,10 @@ import asyncio
 import contextlib
 import re
 from asyncio import StreamReader, StreamReaderProtocol, StreamWriter
+from typing import cast
 
-import serialx
+import serial
+import serial_asyncio
 
 from custom_components.meshtastic.aiomeshtastic.connection import (
     ClientApiConnectionError,
@@ -36,7 +38,7 @@ class SerialConnection(StreamingClientTransport, asyncio.Protocol):
         loop = asyncio.get_running_loop()
         reader = StreamReader(loop=loop)
         protocol = StreamReaderProtocol(reader, loop=loop)
-        transport, _ = await serialx.create_serial_connection(
+        transport, _ = await serial_asyncio.create_serial_connection(
             loop,
             lambda: protocol,
             self._device,
@@ -84,6 +86,7 @@ class SerialConnection(StreamingClientTransport, asyncio.Protocol):
     async def _disconnect(self) -> None:
         if self._writer:
             self._writer.close()
+            cast("serial_asyncio.SerialTransport", self._writer.transport).serial.close()
             self._writer = None
             self._reader = None
 
@@ -121,7 +124,7 @@ class SerialConnection(StreamingClientTransport, asyncio.Protocol):
             if exactly is not None:
                 return await self._reader.readexactly(exactly)
             return await self._reader.read(n=n)
-        except (serialx.SerialException, OSError) as e:
+        except serial.serialutil.SerialException as e:
             raise SerialConnectionError from e
 
     async def _write_bytes(self, data: bytes) -> bool:

--- a/custom_components/meshtastic/aiomeshtastic/connection/serial.py
+++ b/custom_components/meshtastic/aiomeshtastic/connection/serial.py
@@ -6,10 +6,8 @@ import asyncio
 import contextlib
 import re
 from asyncio import StreamReader, StreamReaderProtocol, StreamWriter
-from typing import cast
 
-import serial
-import serial_asyncio
+import serialx
 
 from custom_components.meshtastic.aiomeshtastic.connection import (
     ClientApiConnectionError,
@@ -38,7 +36,7 @@ class SerialConnection(StreamingClientTransport, asyncio.Protocol):
         loop = asyncio.get_running_loop()
         reader = StreamReader(loop=loop)
         protocol = StreamReaderProtocol(reader, loop=loop)
-        transport, _ = await serial_asyncio.create_serial_connection(
+        transport, _ = await serialx.create_serial_connection(
             loop,
             lambda: protocol,
             self._device,
@@ -86,7 +84,6 @@ class SerialConnection(StreamingClientTransport, asyncio.Protocol):
     async def _disconnect(self) -> None:
         if self._writer:
             self._writer.close()
-            cast("serial_asyncio.SerialTransport", self._writer.transport).serial.close()
             self._writer = None
             self._reader = None
 
@@ -124,7 +121,7 @@ class SerialConnection(StreamingClientTransport, asyncio.Protocol):
             if exactly is not None:
                 return await self._reader.readexactly(exactly)
             return await self._reader.read(n=n)
-        except serial.serialutil.SerialException as e:
+        except (serialx.SerialException, OSError) as e:
             raise SerialConnectionError from e
 
     async def _write_bytes(self, data: bytes) -> bool:

--- a/custom_components/meshtastic/manifest.json
+++ b/custom_components/meshtastic/manifest.json
@@ -24,7 +24,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/meshtastic/home-assistant/issues",
   "requirements": [
-    "serialx",
+    "pyserial-asyncio==0.6",
     "aiomqtt"
   ],
   "usb": [

--- a/custom_components/meshtastic/manifest.json
+++ b/custom_components/meshtastic/manifest.json
@@ -24,7 +24,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/meshtastic/home-assistant/issues",
   "requirements": [
-    "pyserial-asyncio==0.6",
+    "serialx",
     "aiomqtt"
   ],
   "usb": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ pip>=21.3.1
 ruff==0.11.8
 
 bleak~=0.22.3
-pyserial-asyncio~=0.6
+serialx==1.8.0
 
 aiomqtt>=1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ pip>=21.3.1
 ruff==0.11.8
 
 bleak~=0.22.3
-serialx==1.8.0
+pyserial-asyncio~=0.6
 
 aiomqtt>=1.2.0


### PR DESCRIPTION
Use modern serialx instead of pyserial-asyncio.
Related article: https://developers.home-assistant.io/blog/2026/04/27/pyserial-to-serialx/