### PR TITLE
fix: avoid double-closing serial transport

### DIFF
--- a/custom_components/meshtastic/aiomeshtastic/connection/serial.py
+++ b/custom_components/meshtastic/aiomeshtastic/connection/serial.py
@@ -6,7 +6,6 @@ import asyncio
 import contextlib
 import re
 from asyncio import StreamReader, StreamReaderProtocol, StreamWriter
-from typing import cast
 
 import serial
 import serial_asyncio
@@ -86,7 +85,6 @@ class SerialConnection(StreamingClientTransport, asyncio.Protocol):
     async def _disconnect(self) -> None:
         if self._writer:
             self._writer.close()
-            cast("serial_asyncio.SerialTransport", self._writer.transport).serial.close()
             self._writer = None
             self._reader = None
 


### PR DESCRIPTION
## Summary
- let the serial transport own shutdown of the underlying pyserial object
- remove the direct raw serial close after StreamWriter.close()

## Why
When a serial device disconnects or times out, SerialTransport.close() schedules its own async connection-lost cleanup, including flushing and closing the serial object. The integration was also immediately closing the raw pyserial object, which can leave the transport cleanup trying to flush a port that is already closed.

On Home Assistant 2026.7 this shows up as repeated log errors like:

```text
Exception in callback SerialTransport._call_connection_lost()
serial.serialutil.PortNotOpenError: Attempting to use a port that is not open
```

This was observed with a CP210x-backed Meshtastic serial connection where the host kernel was also reporting `cp210x ttyUSB1: failed set request 0x12 status: -110` during the same reconnect cadence.

This PR intentionally does not change the pyserial-asyncio dependency, since #161 already covers the pyserial-asyncio-fast migration.

## Testing
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m ruff format . --check`
- `git diff --check`

Note: full `requirements.txt` install was not possible in this local environment because its Python version does not satisfy the pinned Home Assistant version; the checks above were run with the repo-pinned Ruff version `0.11.8`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection shutdown handling to avoid unnecessary low-level serial port closure.
  * Streamlined cleanup so disconnects rely on the standard shutdown flow, reducing the chance of lingering state issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->